### PR TITLE
feature(rate-article): Logged in user can rate an article

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,8 @@
     "react-render-html": "^0.6.0",
     "react-router-dom": "^4.3.1",
     "react-spinners": "^0.5.1",
+    "react-star-rating-component": "^1.4.1",
+    "react-star-ratings": "^2.3.0",
     "react-tagsinput": "^3.19.0",
     "react-toastify": "^4.5.2",
     "redux": "^4.0.1",

--- a/src/actions/ratings/ratingActions.js
+++ b/src/actions/ratings/ratingActions.js
@@ -1,0 +1,48 @@
+import { EDIT_RATING, VIEW_RATING, EDIT_RATING_FAILURE } from './types';
+import axios from 'axios';
+import { toast } from 'react-toastify';
+import { token, BASE_URL } from '../index';
+
+export const getRating = slug => dispatch => {
+  const headers = {
+    'Content-type': 'application/json'
+  };
+  return axios
+    .get(`${BASE_URL}articles/${slug}/`, { headers: headers })
+    .then(response => {
+      dispatch({
+        type: VIEW_RATING,
+        payload: response.data
+      });
+    });
+};
+
+export const updateRating = (updRating, newSlug) => dispatch => {
+  const headers = {
+    Authorization: 'Bearer ' + token,
+    Accept: 'application/json, text/plain, */*',
+    'Content-type': 'application/json'
+  };
+  return axios
+    .put(`${BASE_URL}articles/${newSlug}/rating/`, updRating, {
+      headers: headers
+    })
+
+    .then(response => {
+      dispatch({
+        type: EDIT_RATING,
+        payload: response.data
+      });
+      toast.success("You successfully rated this article");
+    })
+    .catch(error => {
+      dispatch({
+        type: EDIT_RATING_FAILURE,
+        error: error.response
+      });
+      toast.error(error.response.data.error);
+      if (error.response.data.detail) {
+        toast.error('You have not signed in');
+      }
+    });
+};

--- a/src/actions/ratings/ratingActions.test.js
+++ b/src/actions/ratings/ratingActions.test.js
@@ -1,0 +1,52 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import mockAxios from 'jest-mock-axios';
+import { getRating, updateRating } from './ratingActions';
+import { EDIT_RATING, VIEW_RATING } from './types';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+const store = mockStore({});
+
+describe('Testing rate an article', () => {
+  it('dispatch action for getting a profile', () => {
+    mockAxios.get(
+      'https://ah-backend-guardians-staging.herokuapp.com/api/articles/hacking-de9fca080396/rating/'
+    );
+    store.dispatch(getRating());
+    console.log(store.dispatch(getRating()));
+    expect(store.getActions()).toEqual([]);
+  });
+  it('will dispatch an action for editing a rating', () => {
+    mockAxios.put(
+      'https://ah-backend-guardians-staging.herokuapp.com/api/articles/hacking-de9fca080396/rating/',
+      { score: '5' },
+      {
+        Authorization: 'accessToken'
+      }
+    );
+    store.dispatch(updateRating({ score: '5' })).then(() => {
+      expect(store.getActions()).toEqual(
+        expect.objectContaining([{ type: EDIT_RATING }])
+      );
+    });
+  });
+  it('will dispatch an error', () => {
+    mockAxios.put(
+      'https://ah-backend-guardians-staging.herokuapp.com/api/articles/hacking-de9fca080396/rating/',
+      { score: '5' },
+      {
+        Authorization: 'accessToken'
+      }
+    );
+    store.dispatch(updateRating({ score: '9' })).then(() => {
+      console.log(store.getActions());
+
+      expect(store.getActions()).toEqual(
+        expect.objectContaining([
+          { type: EDIT_RATING_FAILURE, error: error.response }
+        ])
+      );
+    });
+  });
+});

--- a/src/actions/ratings/types.js
+++ b/src/actions/ratings/types.js
@@ -1,0 +1,3 @@
+export const EDIT_RATING = 'EDIT_RATING';
+export const VIEW_RATING = 'VIEW_RATING';
+export const EDIT_RATING_FAILURE = 'EDIT_RATING_FAILURE';

--- a/src/components/articles/Article.jsx
+++ b/src/components/articles/Article.jsx
@@ -7,7 +7,9 @@ import Footer from '../Footer/Footer';
 import renderHTML from 'react-render-html';
 import LikeArticle from '../LikeArticle/LikeArticle';
 
-import Bookmark from '../Bookmark/Bookmark'
+import Bookmark from '../Bookmark/Bookmark';
+import EditRatingsView from '../../views/ratings/EditRatingsView';
+
 export class Article extends Component {
   componentDidMount() {
     if (this.props.match) {
@@ -59,6 +61,9 @@ export class Article extends Component {
           <div className="middle">
           <div id="likes">
             <LikeArticle slug={slug}  />
+          </div>
+          <div className="ratings-view">
+              <EditRatingsView slug={slug} />
           </div>
           <Bookmark slug={slug} />
           </div>

--- a/src/components/ratings/EditRating.js
+++ b/src/components/ratings/EditRating.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function EditRating({ onSubmit }) {
+  return (
+    <div>
+      <form
+        onSubmit={onSubmit}
+        className="form-horizontal"
+        role="form"
+        id="editRating"
+      >
+        <input className="btn btn-default" type="submit" value="Save" />
+      </form>
+    </div>
+  );
+}

--- a/src/css/article.css
+++ b/src/css/article.css
@@ -120,3 +120,4 @@ p {
   display: flex;
   justify-content: space-between;
 }
+

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -39,7 +39,34 @@ label {
   background-color: $colour;
 }
 
-// p {
-//   color: $color-alert;
-//   font-size: 12px;
-// }
+.dv-star-rating-star.dv-star-rating-empty-star {
+  padding-right: 1rem;
+}
+
+.dv-star-rating-star.dv-star-rating-full-star {
+  padding-right: 1rem;
+}
+
+.dv-star-rating-star.dv-star-rating-empty-star i {
+  font-size: 1.5rem;
+  color: white;
+  text-shadow: -1px 0 #25abd1, 0 1px #25abd1, 1px 0 #25abd1, 0 -1px #25abd1;
+}
+
+.dv-star-rating-star.dv-star-rating-full-star i {
+  font-size: 1.5rem;
+  color: #25abd1;
+}
+
+.ratings-view {
+  padding-left: 60%;
+}
+
+.dv-star-rating-star.dv-star-rating-empty-star i:hover::before {
+  color: #000000;
+  content: 'you can only rate once';
+  font-size: 12px;
+  margin-top: 45px;
+  position: absolute;
+  white-space: nowrap;
+}

--- a/src/reducers/mainReducer.js
+++ b/src/reducers/mainReducer.js
@@ -10,6 +10,9 @@ import profileReducer from './profileReducer/profileReducer'
 import errorReducer from "./ErrorReducer";
 import { resetEmailReducer } from './resetEmailReducer';
 import { resetPasswordReducer } from './resetPasswordReducer';
+import ratingsReducer from './ratingsReducer/ratingsReducer';
+
+
 
 const mainReducer = combineReducers({
   signin: loginReducer,
@@ -23,6 +26,7 @@ const mainReducer = combineReducers({
   resetPasswordReducer,
   bookmark: bookmarkReducer,
   bookmarks: createBookmarkReducer,
-  likeArticleReducer
+  likeArticleReducer,
+  ratingsReducer
 });
 export default mainReducer;

--- a/src/reducers/profileReducer/profileReducer.test.js
+++ b/src/reducers/profileReducer/profileReducer.test.js
@@ -4,7 +4,7 @@ const initialState = {
 };
 
 describe('get a profile success', () => {
-  it('should be able to get an article', () => {
+  it('should be able to get a profile', () => {
     const profile = {};
 
     const action = {
@@ -15,7 +15,7 @@ describe('get a profile success', () => {
     expect(newState.profile).toEqual(profile);
   });
 
-  it('should be able to edit an article', () => {
+  it('should be able to edit a profile', () => {
     const profile = {};
 
     const action = {

--- a/src/reducers/ratingsReducer/ratingsReducer.js
+++ b/src/reducers/ratingsReducer/ratingsReducer.js
@@ -1,0 +1,38 @@
+import {
+  EDIT_RATING,
+  VIEW_RATING,
+  EDIT_RATING_FAILURE
+} from '../../actions/ratings/types';
+
+const initialState = {
+  rating: {},
+  error: null
+};
+
+const ratingsReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case VIEW_RATING:
+      return {
+        ...state,
+        rating: action.payload,
+        success: true
+      };
+
+    case EDIT_RATING:
+      return {
+        ...state,
+        rating: action.payload,
+        success: true
+      };
+    case EDIT_RATING_FAILURE:
+      return {
+        ...state,
+        error: action.error,
+        success: false
+      };
+    default:
+      return state;
+  }
+};
+
+export default ratingsReducer;

--- a/src/reducers/ratingsReducer/ratingsReducer.test.js
+++ b/src/reducers/ratingsReducer/ratingsReducer.test.js
@@ -1,0 +1,39 @@
+import ratingsReducer from './ratingsReducer';
+const initialState = {
+  rating: {}
+};
+
+describe(`rate an article`, () => {
+  it('should be able to rate an article', () => {
+    const rating = {};
+
+    const action = {
+      type: 'EDIT_RATING',
+      payload: {}
+    };
+    const newState = ratingsReducer(initialState, action);
+    expect(newState.rating).toEqual(rating);
+  });
+  it('should be able to edit a rating', () => {
+    const rating = {};
+    const action = {
+      type: 'VIEW_RATING',
+      payload: {}
+    };
+    const newState = ratingsReducer(initialState, action);
+    expect(newState.rating).toEqual(rating);
+  });
+  it('should fail to rate an article', () => {
+    const rating = {};
+    const action = {
+      type: 'EDIT_RATING_FAILURE',
+      payload: {}
+    };
+    const newState = ratingsReducer(initialState, action);
+    expect(newState.rating).toEqual(rating);
+  });
+  it('should return the default state', () => {
+    const newState = ratingsReducer(initialState, {});
+    expect(newState).toEqual(initialState);
+  });
+});

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import '../css/toast.css';
+import LoginView from '../components/views/loginView/loginView';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
-import LoginView from '../components/views/loginView/loginView';
 import SignUpView from '../components/views/signup/SignUpView';
 import Profile from '../views/Profile/ProfileView';
 import Articles from '../components/MyArticles/Edit Article';
 import GetProfileView from '../views/profiles/GetProfileView';
 import EditProfileView from '../views/profiles/EditProfileView';
+import EditRatingsView from '../views/ratings/EditRatingsView';
 import HomeView from '../views/homeView/homeView';
 import CreateArticle from '../components/articles/CreateArticle';
 import { Article } from "../components/articles";
@@ -27,6 +28,7 @@ const Routes = () => (
         <Route exact path="/" component={HomeView} />
         <Route exact path="/articles/" component={CreateArticle} />
         <Route exact path="/article/:slug" component={Article} />
+        <Route exact path="/rating" component={EditRatingsView} />
         <ToastContainer />
         <Route path="/reset-email" component={ResetEmail} />
         <Route path="/reset-password/:slug" component={ResetPassword} />

--- a/src/views/ratings/EditRatingsView.js
+++ b/src/views/ratings/EditRatingsView.js
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { getRating, updateRating } from '../../actions/ratings/ratingActions';
+import StarRatingComponent from 'react-star-rating-component';
+
+export class EditRatingsView extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      score: '',
+      error: ''
+    };
+  }
+  onStarClick = nextValue => {
+    this.setState({ score: nextValue });
+    const newSlug = this.props.slug;
+    const updRating = {
+      score: this.state.score
+    };
+    this.props.updateRating(updRating, newSlug);
+  };
+
+  componentDidMount() {
+    this.props.getRating(this.props.slug);
+  }
+
+  render() {
+    const { rating } = this.state;
+    return (
+      <div>
+        <StarRatingComponent
+          name="rate1"
+          starCount={5}
+          value={rating}
+          onStarClick={this.onStarClick}
+          id="star-rating"
+        />
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  rating: state.ratingsReducer.rating
+});
+
+export default withRouter(
+  connect(
+    mapStateToProps,
+    { updateRating, getRating }
+  )(EditRatingsView)
+);

--- a/src/views/ratings/EditRatingsView.test.js
+++ b/src/views/ratings/EditRatingsView.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { EditRatingsView } from './EditRatingsView';
+import { shallow, mount } from 'enzyme';
+import mockAxios from 'jest-mock-axios';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+const middlewares = [thunk];
+
+const mockStore = configureMockStore(middlewares);
+
+describe('EditRatingsView', () => {
+  let wrapper;
+  const mockEditRatingfn = jest.fn();
+  const mockgetRatingfn = jest.fn();
+  const historyMock = { push: jest.fn() };
+
+  afterEach(() => {
+    mockEditRatingfn.mock.calls = [];
+  });
+  describe('When form is submitted', () => {
+    wrapper = shallow(
+      <EditRatingsView
+        updateRating={mockEditRatingfn}
+        getRating={mockgetRatingfn}
+        history={historyMock}
+      />
+    );
+    it('Should change the score', () => {
+      wrapper.find('#star-rating').simulate('onStarClick', {
+        target: { score: '5' }
+      });
+      expect(mockEditRatingfn.mock.calls.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?
It enables authenticated users to rate an article

#### Description of Task to be completed?
* Functionality for rate an article if you can log in
* You should not be able to rate an article you created
* UI for rate an article

#### How should this manually tested?
* Vist the URL below:
https://ah-frontend-guardians-pr-23.herokuapp.com/

* Based on _figure 1.0_, you can give an article the rating you desire and then save it. 

#### Notes
* You cannot rate an article when you have not logged in
* You cannot rate an article more than once


#### Relevant pivotal tracker stories
[162685629](https://www.pivotaltracker.com/story/show/162685629)

#### Relevant Screenshots
#### Figure 1.0
![image](https://user-images.githubusercontent.com/30922279/53724279-977d1500-3e7a-11e9-8d29-3e296b0e5567.png)
