### PR TITLE
feat(Bookmark Article): implement list bookmark functionality

### DIFF
--- a/__mocks__/sweetalert.ts
+++ b/__mocks__/sweetalert.ts
@@ -1,0 +1,5 @@
+const mockSweet = jest.genMockFromModule('sweetalert')
+
+mockSweet.create = jest.fn(() => mockSweet)
+
+export default mockSweet

--- a/src/actions/bookmark/bookmarkAction.js
+++ b/src/actions/bookmark/bookmarkAction.js
@@ -19,7 +19,25 @@ export const getBookmark = slug => (dispatch) => {
         }).catch((error) => {
             dispatch({
                 type: 'FETCH_BOOKMARK_FAILURE',
-                payload: error.response.data
+                payload: error.response
+            });
+        })
+}
+
+export const getAllBookmarks = () => (dispatch) => {
+    axios.get(`${BASE_URL}bookmarks/`, { headers })
+        .then((response) => {
+            if (response.data) {
+                console.log(response.data)
+                dispatch({
+                    type: 'FETCH_ALL_BOOKMARK_SUCCESS',
+                    payload: response.data.bookmarks
+                });
+            }
+        }).catch((error) => {
+            dispatch({
+                type: 'FETCH_ALL_BOOKMARK_FAILURE',
+                payload: error.response
             });
         })
 }
@@ -33,7 +51,7 @@ export const createBookmark = slug => dispatch => axios.post(`${BASE_URL}article
     }).catch((error) => {
         dispatch({
             type: 'CREATE_BOOKMARK_FAILURE',
-            payload: error.response.data
+            payload: error.response
         });
     })
 
@@ -42,12 +60,12 @@ export const deleteBookmark = slug => (dispatch) => {
         .then((response) => {
             dispatch({
                 type: 'DELETE_BOOKMARK_SUCCESS',
-                payload: slug,
+                slug: slug,
             });
         }).catch((error) => {
             dispatch({
                 type: 'DELETE_BOOKMARK_FAILURE',
-                payload: error.response.data
+                payload: error.response
             });
         })
 }

--- a/src/actions/bookmark/bookmarkAction.test.js
+++ b/src/actions/bookmark/bookmarkAction.test.js
@@ -2,7 +2,7 @@ import 'babel-polyfill';
 import configureMockStore from 'redux-mock-store'
 import mockAxios from 'axios'
 import thunk from 'redux-thunk'
-import { createBookmark, getBookmark, deleteBookmark } from './bookmarkAction';
+import { createBookmark, getBookmark, deleteBookmark, getAllBookmarks } from './bookmarkAction';
 
 jest.mock('axios')
 
@@ -41,6 +41,45 @@ describe('getBookmark', () => {
         ]
 
         await store.dispatch(getBookmark(''))
+
+        expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    })
+})
+
+describe('getAllBookmark', () => {
+    it('should dispatch success action', async () => {
+        const middlewares = [thunk]
+        const mockStore = configureMockStore(middlewares)
+        const store = mockStore()
+
+        const bookmarks = { 'bookmarks': [{ title: 'hello mate', author: 'reality' }] }
+
+        mockAxios.get.mockImplementationOnce(() => Promise.resolve({ data: bookmarks }))
+
+        const expectedActions = [
+            { type: 'FETCH_ALL_BOOKMARK_SUCCESS', payload: bookmarks.bookmarks },
+        ]
+
+        await store.dispatch(getAllBookmarks())
+
+        expect(store.getActions()).toEqual(expectedActions)
+        expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('should dispatch failure action', async () => {
+        const middlewares = [thunk]
+        const mockStore = configureMockStore(middlewares)
+        const store = mockStore()
+
+        const error = { 'errors': "bookmark doesnot exist exists" }
+
+        mockAxios.get.mockImplementationOnce(() => Promise.reject({ response: 'error' }))
+
+        const expectedActions = [
+            { type: 'FETCH_ALL_BOOKMARK_FAILURE', error: error.errors },
+        ]
+
+        await store.dispatch(getAllBookmarks())
 
         expect(mockAxios.get).toHaveBeenCalledTimes(1)
     })
@@ -91,7 +130,7 @@ describe('createBoomark', () => {
         mockAxios.delete.mockImplementationOnce(() => Promise.resolve({ data: 'you have delete' }))
 
         const expectedActions = [
-            { type: 'DELETE_BOOKMARK_SUCCESS', payload: 'mock_Slug' },
+            { type: 'DELETE_BOOKMARK_SUCCESS', slug: 'mock_Slug' },
         ]
 
         await store.dispatch(deleteBookmark('mock_Slug'))

--- a/src/components/Bookmark/Bookmark.js
+++ b/src/components/Bookmark/Bookmark.js
@@ -34,7 +34,7 @@ export class Bookmark extends Component {
     render() {
         return (
             <div>
-                <i id="bookmark" style={{ color: this.props.bookmark && (this.props.bookmark.bookmarked ? '#00add5' : 'white') }} onClick={this.handleBookmark} className="fas fa-bookmark fa-2x" />
+                <i id="elbookmark" style={{ color: this.props.bookmark && (this.props.bookmark.bookmarked ? '#00add5' : 'white') }} onClick={this.handleBookmark} className="fas fa-bookmark fa-2x" />
             </div>
         );
     }

--- a/src/components/Bookmark/Bookmark.test.js
+++ b/src/components/Bookmark/Bookmark.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import { Bookmark, mapStateToProps } from './Bookmark';
 
@@ -50,11 +50,11 @@ describe('Bookmark', () => {
 
         wrapper = shallow(<Bookmark getBookmark={mockgetBookmarkfn} deleteBookmark={mockdeleteBookmarkfn}
             createBookmark={mockCreateBookmarkfn} {...props} />)
-        wrapper.find('#bookmark').simulate(
+        wrapper.find('#elbookmark').simulate(
             'click',
             { preventDefault() { } },
         )
-        expect(wrapper.find('#bookmark').length).toEqual(1)
+        expect(wrapper.find('#elbookmark').length).toEqual(1)
     })
 
     it('should call createBookmark', () => {
@@ -64,11 +64,11 @@ describe('Bookmark', () => {
 
         wrapper = shallow(<Bookmark getBookmark={mockgetBookmarkfn} deleteBookmark={mockdeleteBookmarkfn}
             createBookmark={mockCreateBookmarkfn} {...props} />)
-        wrapper.find('#bookmark').simulate(
+        wrapper.find('#elbookmark').simulate(
             'click',
             { preventDefault() { } },
         )
-        expect(wrapper.find('#bookmark').length).toEqual(1)
+        expect(wrapper.find('#elbookmark').length).toEqual(1)
     })
     it('mapStateToProps should return the right value', () => {
         const mockedState = {

--- a/src/components/MyBookmarks/DeleteBtn.js
+++ b/src/components/MyBookmarks/DeleteBtn.js
@@ -1,0 +1,41 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import swal from "sweetalert";
+import { deleteBookmark } from "../../actions/bookmark/bookmarkAction";
+
+export class DeleteButton extends Component {
+
+  handleSubmit = (e) => {
+    e.preventDefault();
+    swal({
+      title: "Are you sure?",
+      text: "Once deleted, you will not be able to recover this bookmark!",
+      icon: "warning",
+      buttons: true,
+      dangerMode: true
+    }).then((willDelete) => {
+      if (willDelete) {
+        this.props.deleteBookmark(this.props.slug);
+      }
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <form id="deleteButtonForm" onSubmit={this.handleSubmit}>
+          <input
+            type="submit"
+            className="btn btn-delete"
+            value="Remove"
+          />
+        </form>
+      </div>
+    );
+  }
+}
+
+export default connect(
+  null,
+  { deleteBookmark }
+)(DeleteButton);

--- a/src/components/MyBookmarks/DeleteBtn.test.js
+++ b/src/components/MyBookmarks/DeleteBtn.test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { shallow } from 'enzyme';
+import { DeleteButton } from './DeleteBtn';
+import Swal from 'sweetalert';
+
+jest.mock('sweetalert')
+
+describe('DeleteButton', () => {
+    let wrapper
+    const mockdeleteBookmarkfn = jest.fn()
+
+    beforeEach(() => {
+        wrapper = shallow(<DeleteButton deleteBookmark={mockdeleteBookmarkfn} />)
+    })
+
+    it('renders without crashing', () => {
+
+        expect(wrapper.find('form').length).toEqual(1);
+    });
+});

--- a/src/components/MyBookmarks/MyBookmarks.js
+++ b/src/components/MyBookmarks/MyBookmarks.js
@@ -1,0 +1,56 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { getAllBookmarks, deleteBookmark } from '../../actions/bookmark/bookmarkAction'
+import DeleteButton from "./DeleteBtn";
+import { NavLink } from 'react-router-dom';
+import default_image from "../../images/default_image.png";
+import "../../css/article.css";
+
+export class MyBookmarks extends Component {
+
+    componentDidMount() {
+        this.props.getAllBookmarks();
+    }
+
+    render() {
+        const articleItems = this.props.bookmarks.map(article => (
+            <div className="row flex-container" key={article.id}>
+                <div className="col-md-4 text-center">
+                    <img src={default_image} alt="image" />
+                </div>
+                <div className="col-md-4">
+                    <h3>{article.title}</h3>
+                    <a className="desc">{article.description}</a>
+                    <a><p></p>
+                        <NavLink to={`/article/${article.slug}`} activeClassName="active" className="textlink">
+                            <span>View Article</span>
+                        </NavLink>
+                    </a>
+                    <p></p>
+                </div>
+                <div className="col-md-4">
+                    <div className="buttons mt-5">
+                        <DeleteButton
+                            id={article.id}
+                            slug={article.slug}
+                            triggerParentUpdate={this.updateMyArticles}
+                            getAllBookmarks={this.props.getAllBookmarks}
+                        />
+                        &nbsp;
+                    </div>
+                </div>
+            </div>
+        ));
+        return (
+            <div id="parent">
+                <div className="profileparent">{articleItems.length < 1 ? 'No Bookmarks Found' : articleItems}</div>
+            </div>
+        );
+    }
+}
+
+export const mapStateToProps = state => ({
+    bookmarks: state.bookmarks.bookmarks,
+})
+
+export default connect(mapStateToProps, { getAllBookmarks, deleteBookmark })(MyBookmarks);

--- a/src/components/MyBookmarks/MyBookmarks.test.js
+++ b/src/components/MyBookmarks/MyBookmarks.test.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import { shallow } from 'enzyme';
+import { MyBookmarks, mapStateToProps } from './MyBookmarks';
+
+const props = {
+    bookmarks: [
+        {
+            id: 1,
+            title: "title",
+            description: "desc",
+        }
+    ],
+}
+
+describe('Bookmark', () => {
+    let wrapper
+    const mockgetBookmarkfn = jest.fn()
+    const mockdeleteBookmarkfn = jest.fn()
+
+    beforeEach(() => {
+        wrapper = shallow(<MyBookmarks getAllBookmarks={mockgetBookmarkfn} deleteBookmark={mockdeleteBookmarkfn} {...props} />)
+    })
+
+    it('should call ComponentDidMount', () => {
+        const spy = jest.spyOn(MyBookmarks.prototype, 'componentDidMount');
+
+        wrapper.instance().componentDidMount();
+        expect(spy).toHaveBeenCalled();
+    })
+
+    it('mapStateToProps should return the right value', () => {
+        const mockedState = {
+            bookmarks: {
+                bookmarks: [{
+                    title: 'hello',
+                    message: 'loggedIn',
+                }]
+            },
+        };
+        const state = mapStateToProps(mockedState);
+
+        expect(state.bookmarks).toEqual([{ "message": "loggedIn", "title": "hello" }]);
+    });
+})

--- a/src/components/ProfileBanner/ProfileBanner.js
+++ b/src/components/ProfileBanner/ProfileBanner.js
@@ -2,12 +2,13 @@ import React, { Component } from "react";
 import MyArticles from "../MyArticles/MyArticles";
 import ReadingStats from "../ReadingStats/ReadingStats";
 
+import MyBookmarks from "../MyBookmarks/MyBookmarks";
 export class Banner extends Component {
   constructor(props) {
     super(props);
     this.state = {
       article: true,
-      bookmark: false,
+      bookmarks: false,
       favourites: false,
       readingstats: false
     };
@@ -16,7 +17,7 @@ export class Banner extends Component {
   handleClick(e) {
     this.setState({
       article: false,
-      bookmark: false,
+      bookmarks: false,
       favourites: false,
       readingstats: false
     });
@@ -29,26 +30,27 @@ export class Banner extends Component {
     return (
       <div id="parent" className="container">
         <div className="banner">
-          <span id="article" onClick={this.handleClick.bind(this)}>
+          <span id="article" style={{ color: this.state.article ? 'red' : '#25abd1' }} onClick={this.handleClick.bind(this)}>
             Articles
           </span>
           &nbsp;&nbsp;&nbsp;&nbsp;
-          <span id="bookmarks" onClick={this.handleClick.bind(this)}>
+          <span id="bookmarks" style={{ color: this.state.bookmarks ? 'red' : '#25abd1' }} onClick={this.handleClick.bind(this)}>
             Bookmarks
           </span>
           &nbsp;&nbsp;&nbsp;&nbsp;
-          <span id="favourites" onClick={this.handleClick.bind(this)}>
+          <span id="favourites" style={{ color: this.state.favourites ? 'red' : '#25abd1' }} onClick={this.handleClick.bind(this)}>
             Favourites
           </span>
           &nbsp;&nbsp;&nbsp;&nbsp;
-          <span id="readingstats" onClick={this.handleClick.bind(this)}>
+          <span id="readingstats" style={{ color: this.state.readingstats ? 'red' : '#25abd1' }} onClick={this.handleClick.bind(this)}>
             Statistics
           </span>
         </div>
         <div hidden={!this.state.article}>
           <MyArticles />
         </div>
-        <div hidden={!this.state.bookmark} >
+        <div hidden={!this.state.bookmarks} >
+          <MyBookmarks />
         </div>
         <div hidden={!this.state.favourites} />
         <div hidden={!this.state.readingstats} >

--- a/src/components/ReadingStats/ReadingStats.js
+++ b/src/components/ReadingStats/ReadingStats.js
@@ -15,8 +15,9 @@ export class ReadingStats extends Component {
     let no_of_articles_read = 0;
     let total_read_time = 0;
     if (this.props.readingStats) {
+      let id = 0;
       readingStats = this.props.readingStats.recent_articles.map(stat => (
-        <div className="readingStatCard flex-container">
+        <div className="readingStatCard flex-container" key={id++}>
           <p>
             <h3>{stat.title}</h3>
           </p>

--- a/src/css/article.css
+++ b/src/css/article.css
@@ -113,7 +113,7 @@ p {
   transform:scale(1.3);
   color: red;
 }
-#bookmark {
+#elbookmark {
   text-shadow: 2px 2px 4px #000000;
   cursor: pointer;
 }

--- a/src/reducers/bookmark/bookmarkReducer.js
+++ b/src/reducers/bookmark/bookmarkReducer.js
@@ -1,5 +1,5 @@
 const initialState = {
-    bookmarked: null,
+    bookmarked: false,
     payload: null
 }
 
@@ -21,23 +21,36 @@ export const bookmarkReducer = (state = initialState, action) => {
     }
 }
 
+const initialStates = {
+    bookmarked: null,
+    bookmarks: []
+}
 
-export const createBookmarkReducer = (state = {}, action) => {
+export const createBookmarkReducer = (state = initialStates, action) => {
     switch (action.type) {
         case 'CREATE_BOOKMARK_SUCCESS':
             return {
                 ...state,
                 bookmarked: true,
+                bookmarks: [...state.bookmarks, action.payload]
             };
         case 'CREATE_BOOKMARK_FAILURE':
             return {
                 ...state,
                 bookmarked: false,
             };
+        case 'FETCH_ALL_BOOKMARK_SUCCESS':
+            return {
+                ...state,
+                bookmarked: true,
+                bookmarks: action.payload
+            };
+
         case 'DELETE_BOOKMARK_SUCCESS':
             return {
                 ...state,
                 bookmarked: false,
+                bookmarks: state.bookmarks.filter(bookmark => bookmark.slug !== action.slug)
             };
         default:
             return state

--- a/src/reducers/bookmark/bookmarkReducer.test.js
+++ b/src/reducers/bookmark/bookmarkReducer.test.js
@@ -1,7 +1,8 @@
 import { bookmarkReducer, createBookmarkReducer } from './bookmarkReducer';
 
-const { } = {
-    bookmark: {},
+const initialState = {
+    bookmarked: null,
+    payload: null,
 }
 
 describe('bookmarkReducer', () => {
@@ -14,7 +15,7 @@ describe('bookmarkReducer', () => {
             },
         }
 
-        const newState = bookmarkReducer({}, action)
+        const newState = bookmarkReducer(initialState, action)
 
         expect(newState.bookmarked).toEqual(true)
     })
@@ -23,17 +24,23 @@ describe('bookmarkReducer', () => {
             type: 'FETCH_BOOKMARK_FAILURE',
         }
 
-        const newState = bookmarkReducer({}, action)
+        const newState = bookmarkReducer(initialState, action)
 
         expect(newState.bookmarked).toEqual(false)
     })
     it('should return initial state with no action', () => {
-        expect(bookmarkReducer(undefined, {})).toEqual({
-            bookmarked: null,
+        expect(bookmarkReducer(undefined, initialState)).toEqual({
+            bookmarked: false,
             payload: null
         })
     })
 })
+
+const initialStates = {
+    bookmarked: null,
+    payload: null,
+    bookmarks: [{ id: 1, slug: "tpain", title: 'hello' }]
+}
 
 describe('createBookmarkReducer', () => {
     it('should create a bookmark on action CREATE_BOOKMARK_SUCCESS', () => {
@@ -42,7 +49,17 @@ describe('createBookmarkReducer', () => {
             bookmark: { title: 'hello' },
         }
 
-        const newState = createBookmarkReducer([], action)
+        const newState = createBookmarkReducer(initialStates, action)
+
+        expect(newState.bookmarked).toEqual(true)
+    })
+    it('should fetch a bookmark on action FETCH_ALL_BOOKMARK_SUCCESS', () => {
+        const action = {
+            type: 'FETCH_ALL_BOOKMARK_SUCCESS',
+            bookmarks: [{ title: 'hello' }],
+        }
+
+        const newState = createBookmarkReducer(initialStates, action)
 
         expect(newState.bookmarked).toEqual(true)
     })
@@ -52,20 +69,23 @@ describe('createBookmarkReducer', () => {
             slug: 'tpain',
         }
 
-        const newState = createBookmarkReducer([], action)
+        const newState = createBookmarkReducer(initialStates, action)
 
-        expect(newState.bookmarked).toEqual(false)
+        expect(newState).toEqual({ "bookmarked": false, "bookmarks": [], "payload": null })
     })
     it('should return no bookmarks on action CREATE_BOOKMARK_FAILURE', () => {
         const action = {
             type: 'CREATE_BOOKMARK_FAILURE',
         }
 
-        const newState = createBookmarkReducer([], action)
+        const newState = createBookmarkReducer(initialStates, action)
 
-        expect(newState).toEqual({ "bookmarked": false })
+        expect(newState).toEqual({ bookmarked: false, bookmarks: [{ id: 1, slug: "tpain", title: 'hello' }], payload: null })
     })
     it('should return initial state with no action', () => {
-        expect(createBookmarkReducer(undefined, [])).toEqual({})
+        expect(createBookmarkReducer(undefined, [])).toEqual({
+            "bookmarked": null,
+            "bookmarks": [],
+        })
     })
 })

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -14,6 +14,7 @@ import CreateArticle from '../components/articles/CreateArticle';
 import { Article } from "../components/articles";
 import ResetEmail from '../components/resetPassword/resetEmail';
 import ResetPassword from '../components/resetPassword/resetPassword';
+import MyBookmarks from '../components/MyBookmarks/MyBookmarks';
 
 const Routes = () => (
   <div>
@@ -31,6 +32,7 @@ const Routes = () => (
         <Route exact path="/rating" component={EditRatingsView} />
         <ToastContainer />
         <Route path="/reset-email" component={ResetEmail} />
+        <Route exact path="/bookmarks" component={MyBookmarks} />
         <Route path="/reset-password/:slug" component={ResetPassword} />
       </div>
     </Router>


### PR DESCRIPTION
#### What does this PR do?
This PR lists Bookmarked articles.

#### Description of Task to be completed?
An authenticated user should be able to see all his bookmarked articles in his/her profile and navigate to them

#### How should this be manually tested?
`git clone https://github.com/andela/Ah-frontend-guardians.git`

`cd Ah-frontend-guardians`

`git checkout ft-list-bookmarks-162685641`

`npm install` to install all the projects dependencies

`npm start` to run application.

`Go to your browser and go to this link https://ah-frontend-guardians-pr-32.herokuapp.com/`
`Click sign in which is located in the nav bar and then login`
`Click on the avatar in the navbar to go to your profile`
`Go to bookmarks to see your bookmarks`

#### What are the relevant pivotal tracker stories?
[#162685641](https://www.pivotaltracker.com/story/show/162685641)